### PR TITLE
chore: added regional dr trigger opeartor application

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+
+[Makefile*]
+indent_style = tab

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Get Helm version
         id: helm
         run: |
-          version=$(cat Makefile | grep "VERSION_HELM =" | cut -d'=' -f2 | xargs)
-          echo "version=$version" >> $GITHUB_OUTPUT
+          version=$(grep "VERSION_HELM =" Makefile | cut -d'=' -f2 | xargs)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+---
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - templates/**
+      - Chart.yaml
+      - values.schema.json
+      - values.yaml
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: Lint and test the project
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Get Helm version
+        id: helm
+        run: |
+          version=$(cat Makefile | grep "VERSION_HELM =" | cut -d'=' -f2 | xargs)
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Install helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ steps.helm.outputs.version }}
+
+      - name: Lint chart
+        run: helm lint .
+
+      - name: Test templates
+        run: helm template . > /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin
+*.tgz
+operator_tmp
+regional-dr-trigger-operator*

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,6 @@
+.*
+*.tgz
+regional-dr-trigger-operator*
+bin
+opeartor_tmp
+Makefile

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Red Hat, Inc.
+
+apiVersion: v2
+name: regional-dr-trigger-operator
+description: This Operator will use ODF's Regional DR API for triggering a Failover process for all Applications affiliated with a cluster which is reported as not available by ACM's Managed Cluster API.
+version: 1.0.0
+appVersion: "0.1.0"
+home: https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator
+keywords:
+  - acm
+  - odf
+  - openshift
+  - regional dr
+  - disaster recovery
+icon: https://raw.githubusercontent.com/RHEcosystemAppEng/regional-dr-trigger-operator/main/hack/logo-rh-icon-standard-rgb.png

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 Red Hat, Inc.
+
+################################################
+###### Regional DR Trigger Operator Chart ######
+################################################
+LOCALBIN = $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+OS=$(shell go env GOOS)
+ARCH=$(shell go env GOARCH)
+
+BIN_CURL ?= curl
+BIN_YQ ?= yq
+
+BIN_HELM ?= $(LOCALBIN)/helm
+VERSION_HELM = v3.14.0
+
+OPERATOR_REPO ?= https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator
+OPERATOR_BRANCH =? main
+
+CHART_VERSION ?= $(shell $(BIN_YQ) '.version' Chart.yaml)
+
+TEMP_FOLDER = operator_tmp # ignored by git
+
+.PHONY: lint
+lint: $(BIN_HELM)
+	$(BIN_HELM) lint .
+
+.PHONY: package
+package: $(BIN_HELM)
+	$(BIN_HELM) package .
+
+.PHONY: test
+test: $(BIN_HELM)
+	$(BIN_HELM) template . > /dev/null
+
+.PHONY: install
+install: $(BIN_HELM)
+	$(BIN_HELM) install --generate-name .
+
+.PHONY: generate
+generate:
+	rm -rf $(TEMP_FOLDER)
+	git clone --branch $(OPERATOR_BRANCH) $(OPERATOR_REPO) $(TEMP_FOLDER)
+	cd $(TEMP_FOLDER) && $(MAKE) generate/chart CHART_VERSION=$(CHART_VERSION) CHART_TARGET=$(PWD)
+	rm -rf $(TEMP_FOLDER)
+
+$(BIN_HELM): $(LOCALBIN)
+	$(BIN_CURL) -sSL https://get.helm.sh/helm-$(VERSION_HELM)-$(OS)-$(ARCH).tar.gz | tar xzf - -C $(LOCALBIN) --strip-components=1 --wildcards '*/helm'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Regional DR Trigger Operator Helm Chart
+
+This chart is generated automatically, see [Makefile](Makefile). Please do not attempt to contribute to the chart
+elements directly. Instead, check the [Regional DR Operator repository](https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator)
+for the scripts used to generate this chart.
+
+This chart is used as part of the [Regional Resiliency Pattern](https://github.com/RHEcosystemAppEng/regional-resiliency-pattern).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *Regional Resiliency Pattern* is a [Validated Pattern][vp] derived from the [Multicluster DevSevOps Pattern][devsecops].
 Including the [Regional DR][regional] solution from [Red Hat OpenShift Data Foundation][odf] and the
 [Regional DR Trigger Operator][rdrtrigger]. Used for automated application failover between
-[Red Had Advanced Cluster Management][acm] _Managed Clusters_.
+[Red Had Advanced Cluster Management][acm] *Managed Clusters*.
 
 <details>
 <summary>Click for operator update instructions</summary>

--- a/README.md
+++ b/README.md
@@ -5,10 +5,27 @@ Including the [Regional DR][regional] solution from [Red Hat OpenShift Data Foun
 [Regional DR Trigger Operator][rdrtrigger]. Used for automated application failover between
 [Red Had Advanced Cluster Management][acm] _Managed Clusters_.
 
+<details>
+<summary>Click for operator update instructions</summary>
+<p>
+The <em>Regional DR Operator</em> chart is in <a href="charts/hub/rdrtrigger">charts/hub/rdrtrigger</a>. We use
+[git subtree][subtree], our target is the <a href="https://githuc.com/RHEcosystemAppEng/regional-dr-trigger-operator-chart">original chart</a>.
+We can update it using the following command:
+
+```shell
+# replace ref with the target reference
+git subtree pull --prefix=charts/hub/rdrtrigger \
+https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator-chart.git ref --squash
+```
+
+</p>
+</details>
+
 <!--LINKS-->
 [acm]: https://www.redhat.com/en/technologies/management/advanced-cluster-management
 [devsecops]: https://validatedpatterns.io/patterns/devsecops/
 [odf]: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14
 [rdrtrigger]: https://githuc.com/RHEcosystemAppEng/regional-dr-trigger-operator-chart
 [regional]: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/rdr-solution
+[subtree]: https://docs.github.com/en/get-started/using-git/about-git-subtree-merges
 [vp]: https://validatedpatterns.io/

--- a/templates/ClusterRole-regional-dr-trigger-monitoring-role.yml
+++ b/templates/ClusterRole-regional-dr-trigger-monitoring-role.yml
@@ -1,0 +1,44 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-monitoring-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/templates/ClusterRole-regional-dr-trigger-role.yml
+++ b/templates/ClusterRole-regional-dr-trigger-role.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - cluster.open-cluster-management.io
+    resources:
+      - managedclusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ramendr.openshift.io
+    resources:
+      - drplacementcontrols
+    verbs:
+      - get
+      - list
+      - patch
+      - watch

--- a/templates/ClusterRoleBinding-regional-dr-trigger-monitoring-rb.yml
+++ b/templates/ClusterRoleBinding-regional-dr-trigger-monitoring-rb.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-monitoring-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: regional-dr-trigger-monitoring-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/templates/ClusterRoleBinding-regional-dr-trigger-rb.yml
+++ b/templates/ClusterRoleBinding-regional-dr-trigger-rb.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: regional-dr-trigger-role
+subjects:
+  - kind: ServiceAccount
+    name: regional-dr-trigger-sa
+    namespace: {{ .Values.operator.namespace }}

--- a/templates/Deployment-regional-dr-trigger-operator.yml
+++ b/templates/Deployment-regional-dr-trigger-operator.yml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-operator
+  namespace: {{ .Values.operator.namespace }}
+spec:
+  replicas: {{ .Values.operator.replicas | int }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: operator
+      app.kubernetes.io/part-of: regional-dr-trigger-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: rdrtrigger
+      labels:
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: rdrtrigger-0.1.0
+        app.kubernetes.io/managed-by: kustomize
+        app.kubernetes.io/name: regional-dr-trigger-operator
+        app.kubernetes.io/part-of: regional-dr-trigger-operator
+        app.kubernetes.io/version: 0.1.0
+    spec:
+      containers:
+        - args:
+            - --secure-listen-address=0.0.0.0:8383
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=0
+          image: {{ .Values.operator.kube_rbac_proxy.image }}
+          imagePullPolicy: {{ .Values.operator.kube_rbac_proxy.imagePullPolicy }}
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8383
+              name: https
+              protocol: TCP
+          resources: {{ .Values.operator.kube_rbac_proxy.resources | toYaml | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - args:
+            - rdrtrigger
+            - --leader-election
+            - --probe-address=:8081
+            - --metric-address=127.0.0.1:8080
+          image: {{ .Values.operator.rdrtrigger.image }}
+          imagePullPolicy: {{ .Values.operator.rdrtrigger.imagePullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: rdrtrigger
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: {{ .Values.operator.rdrtrigger.resources | toYaml | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: regional-dr-trigger-sa

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Sources for the operator
+    https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator
+Sources for the chart
+    https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator-chart

--- a/templates/Namespace-regional-dr-trigger.yml
+++ b/templates/Namespace-regional-dr-trigger.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ .Values.operator.namespace }}

--- a/templates/Service-regional-dr-trigger-metrics-service.yml
+++ b/templates/Service-regional-dr-trigger-metrics-service.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-metrics-service
+  namespace: {{ .Values.operator.namespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 8383
+      protocol: TCP
+  selector:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator

--- a/templates/ServiceAccount-regional-dr-trigger-sa.yml
+++ b/templates/ServiceAccount-regional-dr-trigger-sa.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-sa
+  namespace: {{ .Values.operator.namespace }}

--- a/templates/ServiceMonitor-regional-dr-trigger-sm.yml
+++ b/templates/ServiceMonitor-regional-dr-trigger-sm.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: regional-dr-trigger-operator
+    app.kubernetes.io/part-of: regional-dr-trigger-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: regional-dr-trigger-sm
+  namespace: regional-dr-trigger
+namespace: openshift-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.operator.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: regional-dr-trigger-operator

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -15,7 +15,8 @@ clusterGroup:
   - devsecops-ci
   - openshift-storage
   - quay-enterprise
-  
+  - regional-dr-trigger
+
 #  subscriptions:  OpenShift Operator subscriptions from OLM/OperatorHub
 #  - name: the Operator package name (required)
 #    namespace: expected namespace as specified by Operator (defaults to openshift-operators)
@@ -97,8 +98,14 @@ clusterGroup:
       ignoreDifferences:
       - group: operators.openshift.io
         kind: Console
-        jsonPointers: 
+        jsonPointers:
           - /spec/plugins
+
+    rdrtrigger:
+      name: regional-dr-trigger
+      namespace: regional-dr-trigger
+      project: opp
+      path: charts/hub/rdrtrigger
 
     vault:
       name: vault

--- a/values.schema.json
+++ b/values.schema.json
@@ -1,0 +1,83 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "required": [
+        "operator"
+    ],
+    "properties": {
+        "operator": {
+            "type": "object",
+            "required": [
+                "replicas",
+                "kube_rbac_proxy",
+                "rdrtrigger"
+            ],
+            "properties": {
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "kube_rbac_proxy": {
+                    "$ref": "#/$defs/container"
+                },
+                "rdrtrigger": {
+                    "$ref": "#/$defs/container"
+                }
+            }
+        }
+    },
+    "$defs": {
+        "container": {
+            "type": "object",
+            "required": [
+                "image",
+                "imagePullPolicy",
+                "resources"
+            ],
+            "image": {
+                "type": "string"
+            },
+            "imagePullPolicy": {
+                "type": "string",
+                "pattern": "^(Always|Never|IfNotPresent)$"
+            },
+            "properties": {
+                "resources": {
+                    "$ref": "#/$defs/resources"
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "required": [
+                "limits",
+                "requests"
+            ],
+            "properties": {
+                "limits": {
+                    "$ref": "#/$defs/memcpu"
+                },
+                "requests": {
+                    "$ref": "#/$defs/memcpu"
+                }
+            }
+        },
+        "memcpu": {
+            "type": "object",
+            "required": [
+                "cpu",
+                "memory"
+            ],
+            "properties": {
+                "cpu": {
+                    "type": "string",
+                    "pattern": "^(([1-9]+|[0-9]+[.][0-9]+)|([0-9]+m))$"
+                },
+                "memory": {
+                    "type": "string",
+                    "pattern": "^[1-9][0-9]+([EPTGMk]|([EPTGMK]i))$"
+                }
+            }
+        }
+    }
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 Red Hat, Inc.
+operator:
+  replicas: 1
+  kube_rbac_proxy:
+    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi
+  rdrtrigger:
+    image: quay.io/ecosystem-appeng/regional-dr-trigger-operator:0.1.0
+    imagePullPolicy: Always
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  namespace: regional-dr-trigger


### PR DESCRIPTION
- Squashed 'charts/hub/rdrtrigger/' content from commit 1cc24625
- docs: update README with instruction for updating rdrtrigger
- chore: added regional dr trigger application to hub values

I used `git subtree` to incorporate the _rdrtrigger_ chart. The source chart can be found in [RHEcosystemAppEng/regional-dr-trigger-operator-chart](https://github.com/RHEcosystemAppEng/regional-dr-trigger-operator-chart).